### PR TITLE
Remove Masked Singer GraceNote and Add to Non-GraceNote m3u

### DIFF
--- a/services/channels.ts
+++ b/services/channels.ts
@@ -386,8 +386,6 @@ export const CHANNELS = {
         id: 'FOX Digital',
         logo: 'https://tmsimg.fancybits.co/assets/GNLZZGG0027SNRC.png?w=360&h=270',
         name: 'Masked Singer',
-        stationId: '192070',
-        tvgName: 'FMSCFO',
         provider: 'foxone',
       }, 
       120: {

--- a/services/foxone-handler.ts
+++ b/services/foxone-handler.ts
@@ -284,7 +284,6 @@ class FoxOneHandler {
             enabled: false,
             id: 'FOX Digital',
             name: 'Masked Singer',
-            tmsId: '192070',
           },
           {
             enabled: false,


### PR DESCRIPTION
GraceNote data was incorrect for the Fox One Masked Singer Channel.  This change will make it a non-GraceNote channel like some of the Bally stations are and add it to the correct location to pull guide data from the container.