### PR TITLE
Add event channels M3U endpoint with event details in channel names

### DIFF
--- a/index.tsx
+++ b/index.tsx
@@ -10,7 +10,7 @@ import axios from 'axios';
 import fs from 'fs';
 import {createServer} from 'node:https';
 
-import {generateM3u} from './services/generate-m3u';
+import {generateM3u, generateEventChannelsM3u} from './services/generate-m3u';
 import {initDirectories} from './services/init-directories';
 import {generateXml} from './services/generate-xmltv';
 import {launchChannel} from './services/launch-channel';
@@ -433,6 +433,16 @@ app.get('/channels.m3u', async c => {
   return c.body(m3uFile, 200, {
     'Content-Type': 'application/x-mpegurl',
   });
+});
+
+app.get('/event-channels.m3u', async c => {
+  const m3uFile = await generateEventChannelsM3u(getUri(c));
+
+  if (!m3uFile) {
+    return notFound(c);
+  }
+
+  return c.body(m3uFile, 200, {'Content-Type': 'application/x-mpegurl'});
 });
 
 app.get('/linear-channels.m3u', async c => {

--- a/services/generate-m3u.ts
+++ b/services/generate-m3u.ts
@@ -1,7 +1,10 @@
 import _ from 'lodash';
+import moment from 'moment-timezone';
 
+import {db} from './database';
 import {CHANNELS} from './channels';
 import {getLinearStartChannel, getNumberOfChannels, getStartChannel} from './misc-db-service';
+import {IEntry} from './shared-interfaces';
 
 export const generateM3u = async (uri: string, linear = false, excludeGracenote = false): Promise<string> => {
   const startChannel = await getStartChannel();
@@ -49,6 +52,48 @@ export const generateM3u = async (uri: string, linear = false, excludeGracenote 
       m3uFile = `${m3uFile}\n${uri}/channels/${channelNum}.m3u8\n`;
     });
   }
+
+  return m3uFile;
+};
+
+export const generateEventChannelsM3u = async (uri: string): Promise<string> => {
+  const now = Date.now();
+
+  // Only include events that haven't ended yet
+  const entries = await db.entries
+    .findAsync<IEntry>({
+      channel: {$exists: true},
+      linear: {$exists: false},
+      end: {$gt: now},
+    })
+    .sort({start: 1});
+
+  let m3uFile = '#EXTM3U';
+
+  entries.forEach((entry, i) => {
+    const channelNum = i + 1;
+    const time = moment(entry.start).tz('America/New_York').format('MMM D hh:mm A [ET]');
+    const league = entry.sport || entry.network;
+
+    // Normalize MLB-style "Team A @ Team B - HOME" name suffix into a feed label
+    let baseName = entry.name;
+    let feedLabel = entry.feed || null;
+    if (!feedLabel) {
+      const homeAwayMatch = baseName.match(/\s+-\s+(HOME|AWAY)$/i);
+      if (homeAwayMatch) {
+        baseName = baseName.slice(0, homeAwayMatch.index);
+        feedLabel = homeAwayMatch[1].charAt(0).toUpperCase() + homeAwayMatch[1].slice(1).toLowerCase() + ' Feed';
+      }
+    }
+
+    const rawName = feedLabel ? `${baseName} (${feedLabel})` : baseName;
+    const eventName = rawName.replace(/\bat\b/gi, '@');
+
+    const displayName = `${league}: ${eventName} @ ${time} (${entry.network})`;
+
+    m3uFile = `${m3uFile}\n#EXTINF:0 tvg-id="${entry.id}" channel-number="${channelNum}" tvg-chno="${channelNum}" tvg-name="${displayName}" tvg-logo="${entry.image}" group-title="EPlusTV", ${displayName}`;
+    m3uFile = `${m3uFile}\n${uri}/channels/${entry.channel}.m3u8\n`;
+  });
 
   return m3uFile;
 };

--- a/views/Links.tsx
+++ b/views/Links.tsx
@@ -12,6 +12,7 @@ export const Links: FC<ILinksProps> = async ({baseUrl}) => {
   const xmltvUrl = `${baseUrl}/xmltv.xml`;
   const linearXmltvUrl = `${baseUrl}/linear-xmltv.xml`;
   const channelsUrl = `${baseUrl}/channels.m3u`;
+  const eventChannelsUrl = `${baseUrl}/event-channels.m3u`;
   const linearChannelsUrl = `${baseUrl}/linear-channels.m3u`;
   const linearChannelsGc = `${baseUrl}/linear-channels.m3u?gracenote=include`;
   const linearChannelsNoGc = `${baseUrl}/linear-channels.m3u?gracenote=exclude`;
@@ -47,6 +48,15 @@ export const Links: FC<ILinksProps> = async ({baseUrl}) => {
             <td>
               <a href={channelsUrl} class="secondary" target="_blank">
                 {channelsUrl}
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <td>Event Channel</td>
+            <td>One channel per scheduled event with details in the name, no accompanying EPG data</td>
+            <td>
+              <a href={eventChannelsUrl} class="secondary" target="_blank">
+                {eventChannelsUrl}
               </a>
             </td>
           </tr>


### PR DESCRIPTION
This is a really cool container for aggregation of various streaming services, but in non-CDVR software like Dispatcharr, it can be overwhelming to manage large numbers of numbered channels with limited information surfaced at the name, and there exists handling for m3u entries where the event details live in the stream name.

This PR introduces a new m3u endpoint that lists individual event streams with event details in the title, filling the need outlined above.

## New endpoint: `GET /event-channels.m3u`

Each scheduled, non-linear event that hasn't yet ended gets its own M3U entry. The channel URL proxies through the existing EPlusTV channel infrastructure (no new playback plumbing required).

### Channel name format

```
LEAGUE: Event Name (Feed) @ MMM D hh:mm A ET (Network)
```

- **LEAGUE** - `sport` field if present, otherwise `network`
- **Feed** - appended when available (e.g. `Toronto Maple Leafs Feed`, `Home Feed`). MLB-style `- HOME`/`- AWAY` name suffixes are normalized into this label automatically.
- **Time** - event start time expressed in US Eastern (ET) using `moment-timezone`
- **Network** - the source network/provider name

### Example entries

```
NHL: Boston Bruins vs Toronto Maple Leafs (Toronto Maple Leafs Feed) @ Mar 27 07:00 PM ET (NHL.tv)
MLB: Cubs @ Cardinals (Home Feed) @ Mar 27 07:08 PM ET (Fox Sports Midwest)
Softball: Boise State @ Colorado State @ Mar 28 10:00 PM ET (MWC)
```